### PR TITLE
👷 fix: Update go docker image version to 1.22.1

### DIFF
--- a/.github/scripts/calculate-version.sh
+++ b/.github/scripts/calculate-version.sh
@@ -23,10 +23,10 @@ calculate_version() {
     echo "v$major.$minor.$patch"
 }
 
-current_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v-1.0.0")
+current_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 
 case $current_tag in
-    "v-1.0.0") commit_messages=$(git log --pretty=format:"%s") ;;
+    "v0.0.0") commit_messages=$(git log --pretty=format:"%s") ;;
     *) commit_messages=$(git log --pretty=format:"%s" $current_tag...HEAD)
 esac
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4 AS builder
+FROM golang:1.22.1 AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
This PR updates the version of the Go Docker image to 1.22.1. This change is necessary to resolve errors encountered during **go mod download**, ensuring compatibility with dependencies and libraries specified in the project's Go modules.