### PR TITLE
👷 ci: Update workflow action to be triggered on push events to development branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,13 @@ name: Publish
 permissions: write-all
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - development
 
 jobs:
   tag:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged }}
 
     outputs:
       build: ${{ steps.createtag.outputs.build }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to trigger on push events targeting the development branch, replacing the previous trigger on pull request completion events. Previously, the workflow was set to execute upon completion of pull requests. With this change, we ensure that automated processes, such as tagging and deployment, are specifically executed whenever changes are pushed to the development branch.