### PR TITLE
👷 ci: Fix conditional execution of build job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tag
-    if: ${{ always() && !cancelled() && needs.tag.result == 'success' && needs.tag.outputs.build }}
+    if: ${{ always() && !cancelled() && needs.tag.result == 'success' && needs.tag.outputs.build == "true" }}
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This PR addresses an issue where the build job was being executed even if the build output from the tag job was set to false. The previous workflow configuration lacked proper checks for the build output from the tag job. This PR fixes the conditional execution of the build job by ensuring that it only runs when the tag creation job succeeds and when the build output from the tag job is true.