### PR TITLE
👷 ci: Fix syntax error in conditional execution of build job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tag
-    if: ${{ always() && !cancelled() && needs.tag.result == 'success' && needs.tag.outputs.build == "true" }}
+    if: ${{ always() && !cancelled() && needs.tag.result == 'success' && needs.tag.outputs.build == 'true' }}
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This PR addresses a syntax error that occurred in the conditional execution of the build job within the workflow YAML file. The error was due to a mismatch in quotation marks surrounding the boolean value 'true', causing a syntax error during workflow execution. The syntax has been corrected to ensure proper evaluation of the condition.